### PR TITLE
Update jUnit to 5.11

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'java' ]
+        include:
+          - language: java-kotlin
+            build-mode: none # This mode only analyzes Java. Set this to 'autobuild' or 'manual' to analyze Kotlin too.
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -32,8 +34,7 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+        build-mode: ${{ matrix.build-mode }}
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -432,8 +432,8 @@
   <properties>
     <java.version>11</java.version>
     <javadoc-plugin.version>3.8.0</javadoc-plugin.version>
-    <junit-platform.version>1.10.3</junit-platform.version>
-    <junit-jupiter.version>5.10.3</junit-jupiter.version>
+    <junit-platform.version>1.11.0</junit-platform.version>
+    <junit-jupiter.version>5.11.0</junit-jupiter.version>
     <mockito.version>5.12.0</mockito.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
           </properties>
         </configuration>
         <groupId>org.apache.maven.plugins</groupId>
-        <version>3.3.1</version>
+        <version>3.4.0</version>
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
           </execution>
         </executions>
         <groupId>org.apache.maven.plugins</groupId>
-        <version>3.3.1</version>
+        <version>3.4.0</version>
       </plugin>
       <plugin>
         <artifactId>jacoco-maven-plugin</artifactId>


### PR DESCRIPTION
* Remove tokenAuth from Maven publishing plugin's configuration: it's obsolete.

* Remove tokenAuth from Maven publishing plugin's configuration: it's obsolete.

* Optimize import. Skip tests when it runs a demo

* Bump org.hamcrest:hamcrest from 2.2 to 3.0

Bumps [org.hamcrest:hamcrest](https://github.com/hamcrest/JavaHamcrest) from 2.2 to 3.0.
- [Release notes](https://github.com/hamcrest/JavaHamcrest/releases)
- [Changelog](https://github.com/hamcrest/JavaHamcrest/blob/master/CHANGES.md)
- [Commits](https://github.com/hamcrest/JavaHamcrest/compare/v2.2...v3.0)

---
updated-dependencies:
- dependency-name: org.hamcrest:hamcrest dependency-type: direct:development update-type: version-update:semver-major ...



* Bump junit-jupiter.version from 5.10.3 to 5.11.0 and org.junit.platform:junit-platform-commons from 1.10.3 to 1.11.0

---------